### PR TITLE
Add $MODULES_WHITELIST setting

### DIFF
--- a/t/05_whitelist.t
+++ b/t/05_whitelist.t
@@ -1,0 +1,50 @@
+#!perl
+
+use strict;
+use warnings;
+use utf8;
+use FindBin;
+push @INC, "$FindBin::Bin/resource/lib";
+use Test::UsedModules;
+
+use Test::More;
+use Test::Builder::Tester;
+
+my @test_modules = glob "t/resource/lib/Test/UsedModules/Fail/*";
+foreach my $lib (@test_modules) {
+    if ($lib =~ /Fail(\d*).pm/) {
+        require "Test/UsedModules/$1";
+    }
+
+    # test that the code fails with the default whitelist
+    test_out "not ok 1 - $lib";
+    used_modules_ok($lib);
+    test_test (name => "testing used_modules_ok($lib)", skip_err => 1);
+
+    # test that the code passes with the whitelist that includes whatever's specified in the file
+    my $whitelist = get_whitelist($lib);
+    local $Test::UsedModules::MODULES_WHITELIST = [ @$Test::UsedModules::MODULES_WHITELIST, @$whitelist ];
+    used_modules_ok($lib);
+}
+
+done_testing;
+
+sub slurp {
+    my ($filename) = @_;
+
+    open my $fh, '<', $filename;
+    return do { local $/; <$fh> };
+}
+
+sub get_whitelist {
+    my ($filename) = @_;
+
+    my $contents = slurp $filename;
+    my @whitelist;
+    if ( $contents =~ /^# meta: whitelist: (.*?)$/m ) {
+        my $modules = $1;
+        @whitelist = split /\s*,\s*/, $modules;
+    }
+
+    return \@whitelist;
+}

--- a/t/resource/lib/Test/UsedModules/Fail/1.pm
+++ b/t/resource/lib/Test/UsedModules/Fail/1.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use utf8;
 
+# meta: whitelist: Cwd
 use Cwd;
 
 1;

--- a/t/resource/lib/Test/UsedModules/Fail/2.pm
+++ b/t/resource/lib/Test/UsedModules/Fail/2.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use utf8;
 
+# meta: whitelist: File::Basename
 use File::Basename ();
 
 1;

--- a/t/resource/lib/Test/UsedModules/Fail/3.pm
+++ b/t/resource/lib/Test/UsedModules/Fail/3.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use utf8;
 
+# meta: whitelist: File::Spec::Functions
 use File::Spec::Functions qw/catfile/;
 
 1;

--- a/t/resource/lib/Test/UsedModules/Fail/4.pm
+++ b/t/resource/lib/Test/UsedModules/Fail/4.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use utf8;
 
+# meta: whitelist: File::Spec
 require File::Spec;
 
 1;

--- a/t/resource/lib/Test/UsedModules/Fail/5.pm
+++ b/t/resource/lib/Test/UsedModules/Fail/5.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use utf8;
 
+# meta: whitelist: Module::Load
 use Module::Load;
 
 1;

--- a/t/resource/lib/Test/UsedModules/Fail/6.pm
+++ b/t/resource/lib/Test/UsedModules/Fail/6.pm
@@ -5,6 +5,7 @@ use utf8;
 
 use Module::Load;
 
+# meta: whitelist: File::Basename
 load File::Basename;
 
 1;


### PR DESCRIPTION
Hi!

I'm trying to make use of Test::UsedModules in a large Perl project codebase. It turns out that there are in fact many places there that would be in violation and I can't fix all of them at once. I would rather do that incrementally, one module at a time.

Besides, there are some modules (e. g. SOAP::Lite) that are used in a way that Test::UsedModules doesn't detect. SOAP::Lite in particular defines multiple packages in one file and we have instances of files that refer to those packages but not to SOAP::Lite itself. Another case we have is that certain modules are registering handler functions in a global table. When these functions are called, they are being referred to indirectly by name, not called explicitly.

I have managed to patch Test::UsedModules to solve those two problems at once by adding a module whitelist. Modules in the whitelist do not trigger test failures, allowing me to use SOAP::Lite without actually referring to the very same package name, using other packages defined by that instead.

Please take a look. Thank you!
